### PR TITLE
:lipstick: 챌린지 멤버 UI 업데이트

### DIFF
--- a/src/components/AccountPage/getApi.tsx
+++ b/src/components/AccountPage/getApi.tsx
@@ -1,4 +1,4 @@
 import axios from "axios";
 
-export const axiosData = axios.get("./src/test/graphTest.json");
-export const useTest = axios.get("./src/test/useTest.json");
+export const axiosData = axios.get("/src/test/graphTest.json");
+export const useTest = axios.get("/src/test/useTest.json");

--- a/src/components/Challenge/ChallengeChart.tsx
+++ b/src/components/Challenge/ChallengeChart.tsx
@@ -65,6 +65,10 @@ const ChallengeChart = ({ challengeData }: ChallengeDataProps) => {
         },
       },
       y: {
+        grid: {
+          tickLength: 4,
+        },
+
         afterDataLimits: (scale: { max: number }) => {
           scale.max = challengeData.goal_amount;
         },
@@ -94,7 +98,8 @@ const ChallengeChart = ({ challengeData }: ChallengeDataProps) => {
     challengeData.end_date
   );
 
-  const expenseData = challengeData.challengeMemberList.map((data, idx) => {
+  //컬러 배정하는걸로 변경필요
+  const expenseData = challengeData.challengeMemberList.map((data) => {
     let accumulatedAmount = 0;
     const dataset = {
       label: data.nickName,
@@ -106,14 +111,13 @@ const ChallengeChart = ({ challengeData }: ChallengeDataProps) => {
         };
         return dailyAmount;
       }),
+      borderWidth: 3,
       borderColor: data.color,
       backgroundColor: data.color,
     };
 
     return dataset;
   });
-
-  // console.log("expenseData", expenseData);
 
   const data = {
     labels,
@@ -122,18 +126,20 @@ const ChallengeChart = ({ challengeData }: ChallengeDataProps) => {
 
   return (
     <>
-      <div className="bg-base-100 rounded-lg mt-3 shadow">
+      <div className=" overflow-x-auto bg-base-100 rounded-lg mt-3 shadow">
         <div className="text-[9px] font-light text-neutral-500 text-left -my-1 pl-0.5">
           만원
         </div>
-        <Line data={data} options={options} />
+        <div className="w-[140%]">
+          <Line data={data} options={options} />
+        </div>
       </div>
-      <div className="flex items-center bg-base-100 shadow rounded-lg mt-3 text-xs p-2 font-light">
+      <div className="flex items-center bg-base-100 shadow rounded-lg mt-2 text-xs p-2 font-light">
         <MdPeople size={15} className="mr-1 text-neutral-500" />
         <div className="mr-1 pt-0.5">참가자 : </div>
         <div className="pt-0.5">{expenseData.length} 명</div>
       </div>
-      <ul className="bg-base-100 rounded-lg shadow mt-3 text-xs p-2 font-light">
+      <ul className="bg-base-100 rounded-lg shadow mt-2 text-xs p-2 font-light">
         {challengeData.challengeMemberList.map((challengersData) => (
           <li key={challengersData.memberId}>
             <MembersStatus data={challengersData} top={false} />
@@ -145,5 +151,3 @@ const ChallengeChart = ({ challengeData }: ChallengeDataProps) => {
 };
 
 export default ChallengeChart;
-
-const bgColor = ["#e787d5", "#348bdc", "#c4dc6f"];

--- a/src/components/Challenge/ChallengeStatus.tsx
+++ b/src/components/Challenge/ChallengeStatus.tsx
@@ -20,7 +20,7 @@ interface ChallengeDataProps {
 const ChallengeStatus = ({ data }: ChallengeDataProps) => {
   const [isStart, setIsStart] = useState<boolean | null>(null);
   const [startDday, setStartDday] = useState<number | null>(null);
-  const amountString = data.goal_amount.toLocaleString();
+  const goalAmount = data.goal_amount.toLocaleString();
 
   useEffect(() => {
     const today = new Date();
@@ -37,6 +37,12 @@ const ChallengeStatus = ({ data }: ChallengeDataProps) => {
   return (
     <ArticleContainer>
       <div className="w-11/12 mx-auto">
+        <div className="text-cyan-950 text-sm flex justify-center items-center bg-teal-50  rounded-lg  shadow py-3 mb-2">
+          <GiTwoCoins size={17} className="text-yellow-400 mr-1" />
+          <div className="mr-2">목표금액</div>
+          <BiWon size={13} className="mr-0.5" />
+          <div>{goalAmount}</div>
+        </div>
         {isStart ? (
           <div className="text-xs flex justify-around items-center bg-base-100  rounded-lg h-10 shadow mb-2">
             <div className="pt-0.5">
@@ -60,12 +66,6 @@ const ChallengeStatus = ({ data }: ChallengeDataProps) => {
             </div>
           </div>
         )}
-        <div className="text-cyan-950 text-sm flex justify-center items-center bg-base-100  rounded-lg  shadow py-3 mb-2">
-          <GiTwoCoins size={17} className="text-yellow-400 mr-1" />
-          <div className="mr-2">목표금액</div>
-          <BiWon size={13} className="mr-0.5" />
-          <div>{amountString}</div>
-        </div>
 
         {isStart ? (
           <ChallengeChart challengeData={data} />

--- a/src/components/Challenge/MembersStatus.tsx
+++ b/src/components/Challenge/MembersStatus.tsx
@@ -17,7 +17,12 @@ interface Props {
   readonly top: boolean;
 }
 
-const MemberListContainer = styled.div<{ status: 1 | 0; top: boolean }>`
+const MemberListContainer = styled.div<{
+  status: 1 | 0;
+  top: boolean;
+  color: string;
+  mine: boolean;
+}>`
   ${(props) =>
     props.top
       ? css`
@@ -27,9 +32,16 @@ const MemberListContainer = styled.div<{ status: 1 | 0; top: boolean }>`
           ${tw`flex justify-center items-center py-1 rounded text-xs`}
           background: ${props.status === 1 ? "inherit" : "#edecec"};
         `};
+  color: ${(props) => (props.status === 1 ? `${props.color}` : "#787777")};
+  ${(props) =>
+    props.mine
+      ? css`
+          ${tw`bg-teal-50`}
+        `
+      : ``}
 `;
 
-const ColoredTextContainer = styled.div<{ color: string; top: boolean }>`
+const ColoredTextContainer = styled.div<{ top: boolean }>`
   ${(props) =>
     props.top
       ? css`
@@ -38,16 +50,17 @@ const ColoredTextContainer = styled.div<{ color: string; top: boolean }>`
       : css`
           ${tw`w-3/5 flex  items-center`}
         `};
-
-  color: ${(props) => props.color};
 `;
 
 const MembersStatus = ({ data, top }: Props) => {
   const [memberInfo, setMemberInfo] = useState<UserInfo | null>(null);
   const [isOpen, setIsOpen] = useState<boolean | null>(null);
   const [isFirst, setIsFirst] = useState<boolean | null>(null);
+  const [myStatus, setMyStatus] = useState<boolean>(false);
   const ttlAmount = data.total_amount.toLocaleString("ko-KR");
 
+  //실제로는 로그인 정보에서 memberId받기
+  const memberId = 5;
   // memberId로 정보 서버에서 받아오기
   const getMemberData = async () => {
     try {
@@ -60,6 +73,11 @@ const MembersStatus = ({ data, top }: Props) => {
 
   useEffect(() => {
     getMemberData();
+    if (data.memberId === memberId) {
+      setMyStatus(true);
+    } else {
+      setMyStatus(false);
+    }
     if ("isFirst" in data) {
       setIsOpen(true);
       if (data.isFirst) {
@@ -73,7 +91,12 @@ const MembersStatus = ({ data, top }: Props) => {
 
   return (
     <>
-      <MemberListContainer status={isOpen ? data.status : 1} top={top}>
+      <MemberListContainer
+        status={isOpen ? data.status : 1}
+        top={top}
+        color={data.color}
+        mine={myStatus}
+      >
         <div className="relative w-7 flex justify-center items-center text-neutral-400 mr-1">
           {isFirst ? (
             <div className="relative text-amber-400">
@@ -106,7 +129,7 @@ const MembersStatus = ({ data, top }: Props) => {
           )}
         </div>
 
-        <ColoredTextContainer color={data.color} top={top}>
+        <ColoredTextContainer top={top}>
           <div className={`${top ? `w-3/5` : `w-2/5 `} truncate mx-1`}>
             {data.nickName}
           </div>

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -8,7 +8,7 @@ import { GiSevenPointedStar } from "react-icons/Gi";
 import { useLocation, useNavigate } from "react-router-dom";
 
 const HeaderContainer = styled.header`
-  ${tw`btm-nav bg-light-color shadow-inner shadow-[#e0edea]`}
+  ${tw`btm-nav bg-teal-50 shadow-inner shadow-[#e0edea]`}
 `;
 
 const NavBtn = styled.button<{ selected: boolean }>`

--- a/src/constants/challengersColor.ts
+++ b/src/constants/challengersColor.ts
@@ -1,0 +1,12 @@
+export const challengersColor = [
+  "#f59dcb",
+  "#70abe3",
+  "#32a5ed",
+  "#57cf87",
+  "#ce74f7",
+  "#f8b23a",
+  "#43ddc1",
+  "#809af7",
+  "#dae01a",
+  "#d441a6",
+];

--- a/src/pages/ChallengeRoom.tsx
+++ b/src/pages/ChallengeRoom.tsx
@@ -14,6 +14,7 @@ import ChallengeStatus from "../components/Challenge/ChallengeStatus";
 import ChallengeResult from "../components/Challenge/ChallengeResult";
 import { BiWon } from "react-icons/Bi";
 import { GiTwoCoins } from "react-icons/Gi";
+import { challengersColor } from "../constants/challengersColor";
 
 const Container = styled.div`
   ${tw`mx-auto pt-8 text-neutral-600 font-bold text-sm text-center`}
@@ -30,22 +31,33 @@ const ChallengeRoom = () => {
 
   // challengeId로 정보 서버에서 받아오기
   const getMyChallengeList = async () => {
+    let minAmount = 0;
     try {
       const { data } = await axios.get("/src/test/challengeStatus.json");
       if (data.challenge_status === 1) {
         const listWithTotalAmount = data.challengeMemberList
-          .map((info: ChallengeMemberData) => {
+          .map((info: ChallengeMemberData, idx: number) => {
             const ttlAmount = info.recordList
               .map((record) => record.amount)
               .reduce((pre, cur) => pre + cur);
-            return { ...info, total_amount: ttlAmount };
+            return {
+              ...info,
+              total_amount: ttlAmount,
+              color: challengersColor[idx],
+            };
           })
           .sort((a: ChallengeMemberData, b: ChallengeMemberData) => {
             if (!a.total_amount || !b.total_amount) return;
             return a.total_amount - b.total_amount;
           })
           .map((info: ChallengeMemberData, idx: number) => {
-            const ranking = idx === 0 && info.status === 1 ? true : false;
+            if (idx === 0) {
+              minAmount = info.total_amount;
+            }
+            const ranking =
+              info.total_amount === minAmount && info.status === 1
+                ? true
+                : false;
             return { ...info, isFirst: ranking };
           });
         const daysDiff = dDayCalculator(data.end_date);

--- a/src/test/challengeResult.json
+++ b/src/test/challengeResult.json
@@ -10,21 +10,18 @@
     {
       "memberId": 1,
       "nickName": "nickName1",
-      "color": "#e787d5",
       "status": 1,
       "total_amount": 400000
     },
     {
       "memberId": 2,
       "nickName": "nickName2",
-      "color": "#348bdc",
       "status": 1,
       "total_amount": 200000
     },
     {
       "memberId": 3,
       "nickName": "nickName3",
-      "color": "#c4dc6f",
       "status": 0,
       "total_amount": 600000
     }

--- a/src/test/challengeStatus.json
+++ b/src/test/challengeStatus.json
@@ -10,7 +10,6 @@
     {
       "memberId": 1,
       "nickName": "nickName1",
-      "color": "#e787d5",
       "status": 1,
       "recordList": [
         {
@@ -30,7 +29,6 @@
     {
       "memberId": 2,
       "nickName": "nickName2",
-      "color": "#348bdc",
       "status": 1,
       "recordList": [
         {
@@ -54,7 +52,6 @@
     {
       "memberId": 3,
       "nickName": "nickName3",
-      "color": "#c4dc6f",
       "status": 0,
       "recordList": [
         {
@@ -72,6 +69,163 @@
         {
           "date": "2023-06-11",
           "amount": 200000
+        }
+      ]
+    },
+    {
+      "memberId": 4,
+      "nickName": "nickName4",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-03",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-07",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-11",
+          "amount": 20000
+        }
+      ]
+    },
+    {
+      "memberId": 5,
+      "nickName": "nickName5",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-03",
+          "amount": 3000
+        },
+        {
+          "date": "2023-06-07",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-11",
+          "amount": 200000
+        }
+      ]
+    },
+    {
+      "memberId": 6,
+      "nickName": "nickName6",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-03",
+          "amount": 150000
+        },
+        {
+          "date": "2023-06-07",
+          "amount": 3000
+        },
+        {
+          "date": "2023-06-11",
+          "amount": 40000
+        }
+      ]
+    },
+    {
+      "memberId": 7,
+      "nickName": "nickName7",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 50000
+        },
+        {
+          "date": "2023-06-03",
+          "amount": 50000
+        },
+        {
+          "date": "2023-06-07",
+          "amount": 60000
+        },
+        {
+          "date": "2023-06-11",
+          "amount": 100000
+        }
+      ]
+    },
+    {
+      "memberId": 8,
+      "nickName": "nickName8",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 40000
+        },
+        {
+          "date": "2023-06-05",
+          "amount": 150000
+        },
+        {
+          "date": "2023-06-08",
+          "amount": 60000
+        },
+        {
+          "date": "2023-06-11",
+          "amount": 20000
+        }
+      ]
+    },
+    {
+      "memberId": 9,
+      "nickName": "nickName9",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-03",
+          "amount": 150000
+        },
+        {
+          "date": "2023-06-09",
+          "amount": 300000
+        }
+      ]
+    },
+    {
+      "memberId": 10,
+      "nickName": "nickName10",
+      "status": 1,
+      "recordList": [
+        {
+          "date": "2023-06-02",
+          "amount": 10000
+        },
+        {
+          "date": "2023-06-04",
+          "amount": 20000
+        },
+        {
+          "date": "2023-06-05",
+          "amount": 80000
+        },
+        {
+          "date": "2023-06-10",
+          "amount": 40000
         }
       ]
     }


### PR DESCRIPTION
- 오늘언급된 챌린지 멤버 표시 부분 업데이트 했습니다.
-> 내 현황 부분 바탕 강조, 낙오멤버 글자색 그레이톤으로 변경

-멤버별 컬러 처음 데이터 받아오는 시점에서 배정해주도록 조정
(착각했는데 데이터 정렬한담에 배정했었더라구요, 바꿨어요!)

- 최대인원10명으로 데이터 수정해보니 차트에 선들이 너무 뭉쳐서 가로 스크롤 생기도록 하면서 너비를 키웠어요.

- header컬러가 어딘가 칙칙해서 tailwind의 teal-50컬러가 비슷하면서 좀 더 선명하길래 바꿔봤습니다. ㅎㅎ