### PR TITLE
가계부 관련 API 추가

### DIFF
--- a/src/Recoil/challengeHomeFilterAtom.ts
+++ b/src/Recoil/challengeHomeFilterAtom.ts
@@ -1,4 +1,4 @@
-import { atom } from "recoil";
+import { atom, selector } from "recoil";
 
 import {
   FIXED_MIN_VALUE,
@@ -10,14 +10,33 @@ export const textCategoryState = atom({
   default: "total",
 });
 
-export const searchTextState = atom({ key: "title", default: "" });
+export const searchTextState = atom({ key: "searchText", default: "" });
 
-export const minSearchAmount = atom({
+export const minSearchAmountState = atom({
   key: "min_amount",
   default: FIXED_MIN_VALUE,
 });
-export const maxSearchAmount = atom({
+export const maxSearchAmountState = atom({
   key: "max_amount",
   default: FIXED_MAX_VALUE,
 });
 export const searchCategoryState = atom({ key: "category", default: "" });
+
+export const filterParameterSelector = selector({
+  key: "filter_parameter",
+  get: ({ get }) => {
+    const textCategory = get(textCategoryState);
+    const searchText = get(searchTextState);
+    const minSearchAmount = get(minSearchAmountState);
+    const maxSearchAmount = get(maxSearchAmountState);
+    const searchCategory = get(textCategoryState);
+
+    return {
+      text_category: textCategory,
+      search_text: searchText,
+      min_search_amount: minSearchAmount,
+      max_search_amount: maxSearchAmount,
+      search_category: searchCategory,
+    };
+  },
+});

--- a/src/Recoil/index.ts
+++ b/src/Recoil/index.ts
@@ -7,7 +7,7 @@ export const checkedListState = atom<string[]>({
 
 export const startDateState = atom<Date | null>({
   key: "startDate",
-  default: new Date(),
+  default: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
 });
 
 export const endDateState = atom<Date | null>({

--- a/src/api/expenseAPI.ts
+++ b/src/api/expenseAPI.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+
+import { API } from "../constants/api";
+import { expenseFormProps } from "../interface/interface";
+
+export const postExpense = async (data: expenseFormProps) => {
+  try {
+    const response = await axios.post(
+      `${API}/record`,
+      {
+        amount: Number(data.amount),
+        category: data.category,
+        memo: data.memo,
+        paidFor: data.paidFor,
+        payType: data.payType,
+        useDate: data.useDate,
+      },
+      {
+        // headers는 로그인 시 recoil 등에 추가해 놓아야할 것 같음.
+        headers: {
+          Authorization:
+            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiYXV0aCI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNjg3ODc2OTc1fQ.xyjz9cUjNCQe3TbIsBm6c8rDUmU5fjzJm9hsrNQTthQ",
+          Refreshtoken:
+            "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2ODg0Nzk5NzV9.UwtSXO-27OuFamj_STT-le78iK9f8EuQuamzsqaXJ-A",
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`postExpense Error: Time(${new Date()}) ERROR ${error}`);
+  }
+};
+
+export const getRecordedExpense = async (
+  startDate: string,
+  endDate: string,
+  headers: { Authorization: string; Refreshtoken: string }
+) => {
+  try {
+    const response = await axios.get(`${API}/record`, {
+      params: { startDate: startDate, endDate: endDate },
+      headers: headers,
+    });
+    return response.data;
+  } catch (error) {
+    console.error(`getRecordAccount Error: Time(${new Date()}) ERROR ${error}`);
+  }
+};

--- a/src/components/AccountPage/MonthPicker.tsx
+++ b/src/components/AccountPage/MonthPicker.tsx
@@ -1,12 +1,20 @@
 import DatePicker, { registerLocale } from "react-datepicker";
 import { ko } from "date-fns/esm/locale";
+import styled from "styled-components";
+import tw from "twin.macro";
 import { Props } from "../Common/Calendar";
+
+const StyledDatePicker = styled(DatePicker)`
+  color: transparent;
+  text-shadow: 0 0 0 black;
+  ${tw`rounded-lg text-center focus:outline-none`};
+`;
 
 const MonthPicker = ({ selectedDate, handleSelectedDate }: Props) => {
   registerLocale("ko", ko);
   return (
     <div className=" flex items-center">
-      <DatePicker
+      <StyledDatePicker
         id="dp"
         className="w-32 h-6 ml-1 text-center cursor-pointer"
         selected={selectedDate}

--- a/src/components/Challenge/ChallengeHome.tsx
+++ b/src/components/Challenge/ChallengeHome.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import tw from "twin.macro";
 import axios from "axios";
@@ -14,6 +15,7 @@ const Container = styled.div`
 
 export default function ChallengeHome() {
   const [challengeData, setChallengeData] = useState<ChallengeDataProps[]>([]);
+  const [filterParameter, setFilterParameter] = useState();
 
   const getChallengeData = useCallback(async () => {
     try {
@@ -29,7 +31,7 @@ export default function ChallengeHome() {
 
   useEffect(() => {
     getChallengeData();
-  }, []);
+  }, [getChallengeData]);
 
   return (
     <>

--- a/src/components/Common/Slider.tsx
+++ b/src/components/Common/Slider.tsx
@@ -10,15 +10,15 @@ import {
 } from "../../constants/challengeSliderFilter";
 import { SliderBarProps } from "../../interface/interface";
 import {
-  minSearchAmount,
-  maxSearchAmount,
+  minSearchAmountState,
+  maxSearchAmountState,
 } from "../../Recoil/challengeHomeFilterAtom";
 
 export default function Slider() {
   const [rangeMinValue, setRangeMinValue] =
-    useRecoilState<number>(minSearchAmount);
+    useRecoilState<number>(minSearchAmountState);
   const [rangeMaxValue, setRangeMaxValue] =
-    useRecoilState<number>(maxSearchAmount);
+    useRecoilState<number>(maxSearchAmountState);
   const [rangeMinPercent, setRangeMinPercent] = useState<number>(0);
   const [rangeMaxPercent, setRangeMaxPercent] = useState<number>(100);
 

--- a/src/components/Expenses/ExpensesForm.tsx
+++ b/src/components/Expenses/ExpensesForm.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, Dispatch, SetStateAction, useRef, useState } from "react";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, SubmitHandler } from "react-hook-form";
 import * as Yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import InformModal from "../Common/InformModal";
@@ -11,6 +11,9 @@ import { IoCloseOutline } from "react-icons/Io5";
 import Calendar from "../Common/Calendar";
 import { Category, categoryList } from "../../constants/expenseCategory";
 import { SHOW_MODAL_DELAY } from "../../constants/modalTime";
+
+import { postExpense } from "../../api/expenseAPI";
+import { expenseFormProps } from "../../interface/interface";
 
 const Container = styled.div`
   ${tw`mx-auto w-11/12 pt-8 text-neutral-600 font-bold text-sm`}
@@ -91,36 +94,14 @@ const ExpensesForm = ({ formEditor }: ExpensesFormProps) => {
     setSelectedCategory(null);
   };
 
-  const handleExpenseSubmit = (formdata: ExpensesFormData) => {
+  const handleExpenseSubmit: SubmitHandler<expenseFormProps> = async (
+    formdata: expenseFormProps
+  ) => {
     console.log(formdata);
+    const response = await postExpense(formdata);
+    console.log(response.data);
+
     if (!dialogRef.current) return;
-    //amount는 숫자로 바꿔서 서버로 보내야함
-    //날짜 포맷 확인 필요
-
-    //서버에 지출등록
-    // const { data } = await axios.post(
-    //   "http://13.124.58.137/record",
-    //   {
-    //     amount: 10000,
-    //     category: "FOOD",
-    //     memo: "메모",
-    //     paidFor: "식당",
-    //     payType: "CARD",
-    //     useDate: "6/24/2023",
-    //   }
-    //   // {
-    //   //   headers: {
-    //   //     Authorization:
-    //   //       "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiYXV0aCI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNjg3NjA4NTIxfQ.gpPDNP5lCSk_ASPXsgyFSvtDA0OGkevyHygUhAFu-UM",
-    //   //     Refreshtoken:
-    //   //       "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2ODgyMTE1MjF9.l1UMkaEHfF8qdz4jzooFdgz9j3QpIL0KfmmARsGAjW4",
-    //   //   },
-    //   // }
-    // );
-    // console.log(data);
-    //onsuccess에
-    // reset();
-
     dialogRef.current.showModal();
     setTimeout(() => {
       if (!dialogRef.current) return;

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -77,3 +77,12 @@ export interface ChallengeDataProps {
   readonly maxPeople: number;
   readonly cnt: number;
 }
+
+export interface expenseFormProps {
+  readonly amount: string;
+  readonly payType: string;
+  readonly category: string;
+  readonly paidFor: string;
+  readonly useDate: string;
+  readonly memo?: string | null;
+}


### PR DESCRIPTION
1. ### 지출 조회 API 작성
- API에 맞게 변수 수정.
- 지난 달, 다음 달 변경 시 startDate, endDate 수정되도록 변경.
- 개별 월 조회 시 startDate, endDate 수정되도록 변경.
- recoil의 startDate 초기 값을 1일로 설정되도록 변경.
2. ### 지출 등록 API 작성
3. ### 기타
- 가계부 DatePicker style 변경
- 챌린지 홈 파리미터 변경