### PR TITLE
게시판 조회 업데이트

### DIFF
--- a/src/api/axiosInterceptors.ts
+++ b/src/api/axiosInterceptors.ts
@@ -26,7 +26,6 @@ axios.interceptors.response.use(
     if (response.status === 400) {
       if (response.data.errorCode === "EXPIRED_TOKEN") {
         const originalRequest = response.config;
-
         await tokenRefresh();
         console.log("토큰 리프레쉬");
         const refreshToken = localStorage.getItem("refreshToken");

--- a/src/api/boardAPI.ts
+++ b/src/api/boardAPI.ts
@@ -5,7 +5,7 @@ const challengeId = 1;
 export const postBoard = async (text: string, showImage: string[]) => {
   try {
     const response = await axios.post(
-      `${API}/posts?challengId=${challengeId}`,
+      `${API}/posts?challengeId=${challengeId}`,
       {
         content: text,
         imageUrlList: showImage,
@@ -14,5 +14,43 @@ export const postBoard = async (text: string, showImage: string[]) => {
     return response.data;
   } catch (error) {
     console.error(`postBoard Error : Time(${new Date()}) ERROR ${error}`);
+  }
+};
+
+export const getPosts = async (challengeId: number, page: number) => {
+  try {
+    const response = await axios.get(
+      `${API}/posts/challenges/${challengeId}?page=${page}&size=1`
+    );
+    return response.data.data;
+  } catch (error) {
+    console.error(`getPosts Error : Time(${new Date()}) ERROR ${error}`);
+  }
+};
+
+export const deletePost = async (postId: number) => {
+  try {
+    const response = await axios.delete(`${API}/posts/${postId}`);
+    return response.data;
+  } catch (error) {
+    console.error(`getPosts Error : Time(${new Date()}) ERROR ${error}`);
+  }
+};
+
+export const heartPost = async (postId: number) => {
+  try {
+    const response = await axios.post(`${API}/hearts?postId=${postId}`);
+    return response.data;
+  } catch (error) {
+    console.error(`heartPost Error : Time(${new Date()}) ERROR ${error}`);
+  }
+};
+
+export const heartDelete = async (postId: number) => {
+  try {
+    const response = await axios.delete(`${API}/hearts?postId=${postId}`);
+    return response.data;
+  } catch (error) {
+    console.error(`heartDelete Error : Time(${new Date()}) ERROR ${error}`);
   }
 };

--- a/src/components/Board/BoardForm.tsx
+++ b/src/components/Board/BoardForm.tsx
@@ -12,6 +12,7 @@ import {
 import DialogModal from "../Common/Dialog";
 import { SHOW_MODAL_DELAY } from "../../constants/modalTime";
 import { postBoard } from "../../api/boardAPI";
+import { useMutation, useQueryClient } from "react-query";
 
 interface NewBoardFormProp {
   onClick: MouseEventHandler<HTMLButtonElement>;
@@ -22,6 +23,17 @@ export default function NewBoardForm({ onClick }: NewBoardFormProp) {
   const [text, setText] = useRecoilState(textState);
   const [, setTextLength] = useRecoilState(textLengthState);
   const contentsDialogRef = useRef<HTMLDialogElement>(null);
+
+  //게시판 구현위해 useMutation으로 변경함 아래 1은 실제 챌린지 id로 변경필요
+  const queryClient = useQueryClient();
+  const { mutate: postCreateMutate } = useMutation(
+    () => postBoard(text, showImg),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["challengeBoard", 1]);
+      },
+    }
+  );
 
   const onSubmitHandler = (e: FormEvent<HTMLFormElement>) => {
     if (showImg.length === 0 && text === "") {
@@ -34,7 +46,8 @@ export default function NewBoardForm({ onClick }: NewBoardFormProp) {
       }, SHOW_MODAL_DELAY);
       return false;
     } else {
-      postBoard(text, showImg);
+      // postBoard(text, showImg);
+      postCreateMutate();
       setShowImg([]);
       setText("");
       setTextLength(0);

--- a/src/components/Board/BoardItem.tsx
+++ b/src/components/Board/BoardItem.tsx
@@ -1,0 +1,146 @@
+import {
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react";
+import Dropdown from "../Common/Dropdown";
+import { BoardContent } from "./BoardList";
+import ImageCarousel from "./ImageCarousel";
+import { AiFillHeart, AiOutlineHeart } from "react-icons/Ai";
+import { BsPencil, BsTrash, BsPersonFill } from "react-icons/Bs";
+import { UseQueryResult } from "react-query";
+import { UserData } from "../../interface/interface";
+import { useUser } from "../../api/membersAPI";
+import { heartDelete, heartPost } from "../../api/boardAPI";
+import { differenceInHours, differenceInMinutes, isToday } from "date-fns";
+
+interface BoardItemProps {
+  readonly post: BoardContent;
+  readonly confirmRef: RefObject<HTMLDialogElement>;
+  readonly dispatch: Dispatch<SetStateAction<number | null>>;
+}
+
+const BoardItem = ({ post, confirmRef, dispatch }: BoardItemProps) => {
+  const { data: userInfo }: UseQueryResult<UserData> = useUser();
+  const [heartState, setHeartState] = useState(false);
+  const [heartCount, setHeartCount] = useState(0);
+  const [formattedDate, setFormattedDate] = useState("");
+
+  useEffect(() => {
+    setHeartState(post.hasHeart);
+    setHeartCount(post.heartCnt);
+  }, [post]);
+
+  useEffect(() => {
+    const date = new Date(post.createdAt);
+    const now = new Date();
+    if (isToday(date)) {
+      const hoursDifference = differenceInHours(now, date);
+      if (hoursDifference <= 0) {
+        const minutesDifference = differenceInMinutes(now, date);
+        setFormattedDate(`${minutesDifference}분 전`);
+      } else {
+        setFormattedDate(`${hoursDifference}시간 전`);
+      }
+    } else {
+      const createdDate = date.toLocaleDateString("en-US");
+      setFormattedDate(createdDate);
+    }
+  }, [post]);
+
+  const handleHeart = async () => {
+    if (heartState) {
+      setHeartState(false);
+      setHeartCount((count) => count - 1);
+      await heartDelete(post.id);
+    } else {
+      setHeartState(true);
+      setHeartCount((count) => count + 1);
+      await heartPost(post.id);
+    }
+  };
+
+  const confirmDelete = (id: number) => {
+    if (!confirmRef.current || !id) return;
+    dispatch(id);
+    confirmRef.current.showModal();
+  };
+  return (
+    <>
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex justify-between items-center ml-1">
+          {
+            <div className="w-9 h-9  rounded-full overflow-hidden bg-[#f0f8f6] text-accent shadow-lg">
+              {post.author.profileImageUrl ? (
+                <img
+                  src={post.author.profileImageUrl}
+                  className="w-full"
+                  alt="프로필이미지"
+                />
+              ) : (
+                <BsPersonFill size={36} className="mt-1" />
+              )}
+            </div>
+          }
+          <div className="text-xs text-cyan-900 pt-2 pl-2">
+            {post.author.nickname}
+          </div>
+        </div>
+
+        {userInfo?.memberId === post.author.memberId ? (
+          <Dropdown>
+            <li className="text-xs w-20 px-0 ">
+              <div
+                // onClick={() =>)}
+                className=" w-full mx-auto"
+              >
+                <BsPencil size="13" />
+                <p className="shrink-0">수정</p>
+              </div>
+            </li>
+            <li className="text-error text-xs w-20 px-0">
+              <div
+                onClick={() => confirmDelete(post.id)}
+                className="w-full mx-auto"
+              >
+                <BsTrash size="13" />
+                <p className="shrink-0">삭제</p>
+              </div>
+            </li>
+          </Dropdown>
+        ) : null}
+      </div>
+
+      {post.imageList.length !== 0 ? (
+        <ImageCarousel imgList={post.imageList} />
+      ) : null}
+
+      <p className="text-left font-normal p-2 py-3 mt-2 border-t border-accent-focus/60">
+        {post.postContent}
+      </p>
+      <div className="flex justify-between mb-1 px-2">
+        <div className="mr-2 flex items-center">
+          <button
+            onClick={handleHeart}
+            className="btn btn-ghost btn-xs p-0 hover:bg-base-100"
+          >
+            {heartState ? (
+              <AiFillHeart size={20} className=" text-rose-500" />
+            ) : (
+              <AiOutlineHeart size={20} />
+            )}
+          </button>
+
+          <p className="text-xs mx-1 pt-1 font-light">{heartCount}</p>
+        </div>
+        <div className="text-[10.5px] font-normal text-right pt-1">
+          {formattedDate}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default BoardItem;

--- a/src/components/Common/ConfirmModal.tsx
+++ b/src/components/Common/ConfirmModal.tsx
@@ -19,7 +19,10 @@ const ConfirmModal = ({ dialogRef, confirm, onConfirm }: Props) => {
         <div className="text-sm font-bold text-center">{confirm}</div>
         <div className="flex justify-center space-x-2 mt-6">
           <button className="btn btn-sm btn-outline w-1/3">취소</button>
-          <button onClick={onConfirm} className="btn btn-sm w-1/3">
+          <button
+            onClick={onConfirm}
+            className="btn btn-sm btn-accent text-base-100 w-1/3"
+          >
             확인
           </button>
         </div>

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -8,11 +8,11 @@ import { GiSevenPointedStar } from "react-icons/Gi";
 import { useLocation, useNavigate } from "react-router-dom";
 
 const HeaderContainer = styled.header`
-  ${tw`btm-nav h-20 bg-teal-50 shadow-inner shadow-[#e0edea] `}
+  ${tw`btm-nav h-20 bg-teal-50 rounded-t-2xl`}
 `;
 
 const NavBtn = styled.button<{ selected: boolean }>`
-  ${tw`text-xs text-neutral-400`}
+  ${tw`text-xs text-gray-400`}
   ${({ selected }) => selected && tw`text-accent font-bold`}
 `;
 const icons = {
@@ -23,6 +23,7 @@ const icons = {
 } as const;
 type NavMenu = keyof typeof icons;
 
+//src\assets\savegame_300x300.png
 interface Menu {
   readonly name: NavMenu;
   readonly pathname: string;

--- a/src/components/Common/InformModal.tsx
+++ b/src/components/Common/InformModal.tsx
@@ -2,6 +2,7 @@ import { RefObject } from "react";
 import styled from "styled-components";
 import tw from "twin.macro";
 import { CgSpinner } from "react-icons/Cg";
+import { BsCheckCircleFill } from "react-icons/Bs";
 
 const Dialog = styled.dialog`
   ::backdrop {
@@ -16,8 +17,6 @@ interface Props {
   readonly inform: string;
 }
 
-//loading은 useQuery등을 통해 loading값이 있을때 넘겨준다.
-
 const InformModal = ({ dialogRef, loading, inform }: Props) => {
   return (
     <Dialog ref={dialogRef}>
@@ -27,7 +26,10 @@ const InformModal = ({ dialogRef, loading, inform }: Props) => {
             <CgSpinner size={35} className="animate-spin text-accent-focus" />
           </div>
         ) : (
-          <div>{inform}</div>
+          <div className="flex flex-col justify-center items-center">
+            <BsCheckCircleFill size={20} className="text-accent mb-3" />
+            <div>{inform}</div>
+          </div>
         )}
       </form>
     </Dialog>

--- a/src/components/MyPage/NicknameForm.tsx
+++ b/src/components/MyPage/NicknameForm.tsx
@@ -24,15 +24,22 @@ interface Props {
 const NicknameForm = ({ formEditor, informChangeRef }: Props) => {
   const queryClient = useQueryClient();
   const setIsLoading = useSetRecoilState(loadingAtom);
-  const [duplicationCheck, setDuplicationCheck] = useState({
+  const [duplicationCheck, setDuplicationCheck] = useState<{
+    check: boolean;
+    result: true | string;
+  }>({
     check: false,
-    result: false,
+    result: "",
   });
   const nicknameSchema = Yup.object({
     nickname: Yup.string()
       .min(1, "입력된 내용이 없습니다.")
       .max(10, "10자 이내로 작성해주세요.")
-      .test("isDuplicated", "중복 확인해주세요.", () => duplicationCheck.result)
+      .test(
+        "isDuplicated",
+        "중복 확인해주세요.",
+        () => duplicationCheck.result === true
+      )
       .required("변경할 닉네임을 입력해주세요."),
   });
   type NicknameFormData = Yup.InferType<typeof nicknameSchema>;
@@ -61,7 +68,7 @@ const NicknameForm = ({ formEditor, informChangeRef }: Props) => {
   useEffect(() => {
     setDuplicationCheck({
       check: false,
-      result: false,
+      result: "",
     });
   }, [nicknameInput]);
 
@@ -70,6 +77,10 @@ const NicknameForm = ({ formEditor, informChangeRef }: Props) => {
 
     const res = await checkNickname(nicknameInput);
     const isPassed = res.success;
+    const msg =
+      res.data === "중복된 닉네임 입니다."
+        ? res.data
+        : "공백, 특수문자는 제외해주세요.";
 
     if (isPassed) {
       setDuplicationCheck({
@@ -79,7 +90,7 @@ const NicknameForm = ({ formEditor, informChangeRef }: Props) => {
     } else {
       setDuplicationCheck({
         check: true,
-        result: false,
+        result: msg,
       });
     }
     clearErrors("nickname");
@@ -108,13 +119,13 @@ const NicknameForm = ({ formEditor, informChangeRef }: Props) => {
           />
           {duplicationCheck.check ? (
             <div>
-              {duplicationCheck.result ? (
+              {duplicationCheck.result === true ? (
                 <p className="absolute right-3 bottom-0.5 text-[11px] font-light text-success text-center bg-base-100">
                   사용가능한 닉네임입니다.
                 </p>
               ) : (
                 <p className="absolute right-3 bottom-0.5 text-[11px] font-light text-error text-center bg-base-100">
-                  중복된 닉네임입니다.
+                  {duplicationCheck.result}
                 </p>
               )}
             </div>


### PR DESCRIPTION
- 헤더 그림자 삭제

- 인폼모달에 체크모양 아이콘 추가

- 컨펌모달 확인버트 컬러 변경

- 닉네임중복검사결과 중 공백/특수문자 안된다는 결과에 대한 에러메시지 추가

- 게시판 조회 업데이트
  - 조회부분 useQuery로 함에 따라 게시물생성쪽 api요청 useMutation으로 변경함 (충돌할까봐 이쪽은 안건들이려고 했는데 안그러면 조회부분에서 업데이트가 있어도 화면에 반영이 안돼서 어쩔수없이 건들고 원래 코드는 혼선있으실까봐 지우진 않고 주석처리했어요!)
  - 페이지네이션 확인하려고 한페이지당 사이즈를 1개로 해놨는데 나중에 10개정도로 바꿀것임
  - 무한스크롤의 더보기 버튼은 임시입니다. (없앨것임)
  - 게시물 수정버튼은, 게시물생성쪽에 수정관련 분기처리가 들어가게 될 것같아서 생성쪽 다 마무리되면 건들여야할 것같아 연결안된 상태