### PR TITLE
가계부 버그 수정

### DIFF
--- a/src/Recoil/expenseRecord.ts
+++ b/src/Recoil/expenseRecord.ts
@@ -5,3 +5,8 @@ export const expenseRecordAtom = atom<ExpenseRecord | null>({
   key: "expenseRecordAtom",
   default: null,
 });
+
+export const selectedExpenseDateState = atom<Date>({
+  key: "selectedExpenseDateState",
+  default: new Date(),
+});

--- a/src/components/AccountPage/Account.tsx
+++ b/src/components/AccountPage/Account.tsx
@@ -24,7 +24,10 @@ import LoadingSpinner from "../Common/LoadingSpinner.js";
 import { BsPencil, BsTrash } from "react-icons/Bs";
 import Dropdown from "../Common/Dropdown.js";
 import ConfirmModal from "../Common/ConfirmModal.js";
-import { expenseRecordAtom } from "../../Recoil/expenseRecord.js";
+import {
+  expenseRecordAtom,
+  selectedExpenseDateState,
+} from "../../Recoil/expenseRecord.js";
 import { useNavigate } from "react-router-dom";
 import ExpensesForm from "../Expenses/ExpensesForm.js";
 
@@ -36,7 +39,8 @@ export default function Account() {
   const [startDate, setStartDate] = useRecoilState(startDateState);
   const [categoryFilterList, setCategoryFilterList] =
     useRecoilState(checkedListState);
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [selectedDateForGetData, setSelectedDateForGetData] =
+    useRecoilState<Date>(selectedExpenseDateState);
   const [analyze, setAnalyze] = useState(false);
   const [expenseData, setExpenseData] = useState<ExpenseRecord[]>([]);
   const confirmDialogRef = useRef<HTMLDialogElement>(null);
@@ -75,39 +79,34 @@ export default function Account() {
     getUseData();
   }, [getUseData]);
 
-  const filterDate = expenseData.filter((d) => {
-    if (getDayFunc(selectedDate.toString(), 1) === getDayFunc(d.useDate, 1)) {
-      return d;
-    }
-  });
-
-  const totalAmount = filterDate.reduce(
+  const totalAmount = expenseData.reduce(
     (acc, cur) => acc + Number(cur.amount),
     0
   );
-  const year = new Date(selectedDate).getFullYear();
-  const prevMonth = new Date(selectedDate).getMonth();
-  const nextMonth = new Date(selectedDate).getMonth() + 1;
+
+  const year = new Date(selectedDateForGetData).getFullYear();
+  const prevMonth = new Date(selectedDateForGetData).getMonth();
+  const nextMonth = new Date(selectedDateForGetData).getMonth() + 1;
 
   const onChangeMonth = (date: Date) => {
-    setSelectedDate(date);
     setStartDate(new Date(date.getFullYear(), date.getMonth(), 1));
     setEndDate(new Date(date.getFullYear(), date.getMonth() + 1, 0));
   };
 
   const onClickPrev = () => {
-    setSelectedDate(new Date(year, prevMonth - 1));
+    setSelectedDateForGetData(new Date(year, prevMonth - 1));
     setStartDate(new Date(year, prevMonth - 1, 1));
     setEndDate(new Date(year, prevMonth, 0));
   };
   const onClickNext = () => {
-    setSelectedDate(new Date(year, nextMonth));
+    setSelectedDateForGetData(new Date(year, nextMonth));
     setStartDate(new Date(year, nextMonth, 1));
     setEndDate(new Date(year, nextMonth + 1, 0));
   };
   const handleFilterReset = () => {
     setStartDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
     setEndDate(new Date());
+    setSelectedDateForGetData(new Date());
     setCategoryFilterList([]);
     setisFilterd(false);
   };
@@ -142,7 +141,7 @@ export default function Account() {
               onClick={onClickPrev}
             />
             <MonthPicker
-              selectedDate={selectedDate}
+              selectedDate={selectedDateForGetData}
               handleSelectedDate={onChangeMonth}
             />
             <SlArrowRight
@@ -221,8 +220,8 @@ export default function Account() {
                 ) : (
                   <></>
                 )}
-                {filterDate.length > 0 ? (
-                  filterDate.map((d, idx) => (
+                {expenseData.length > 0 ? (
+                  expenseData.map((d, idx) => (
                     <div key={idx} className="w-full border p-4 mb-2">
                       <div className="flex w-full justify-between mb-4 pb-2 border-b-4">
                         <div>{getDayFunc(d.useDate, 2)}</div>

--- a/src/components/AccountPage/MonthPicker.tsx
+++ b/src/components/AccountPage/MonthPicker.tsx
@@ -3,6 +3,8 @@ import { ko } from "date-fns/esm/locale";
 import styled from "styled-components";
 import tw from "twin.macro";
 import { Props } from "../Common/Calendar";
+import { useRecoilValue } from "recoil";
+import { selectedExpenseDateState } from "../../Recoil/expenseRecord";
 
 const StyledDatePicker = styled(DatePicker)`
   color: transparent;
@@ -10,14 +12,15 @@ const StyledDatePicker = styled(DatePicker)`
   ${tw`rounded-lg text-center focus:outline-none`};
 `;
 
-const MonthPicker = ({ selectedDate, handleSelectedDate }: Props) => {
+const MonthPicker = ({ handleSelectedDate }: Props) => {
+  const selectedDateForGetData = useRecoilValue(selectedExpenseDateState);
   registerLocale("ko", ko);
   return (
     <div className=" flex items-center">
       <StyledDatePicker
         id="dp"
         className="w-32 h-6 ml-1 text-center cursor-pointer"
-        selected={selectedDate}
+        selected={selectedDateForGetData}
         locale="ko"
         shouldCloseOnSelect
         onChange={(date: Date) => handleSelectedDate(date)}

--- a/src/components/AccountPage/Submit.tsx
+++ b/src/components/AccountPage/Submit.tsx
@@ -8,18 +8,23 @@ import {
   checkedListState,
   isfilteredState,
 } from "../../Recoil";
+import { selectedExpenseDateState } from "../../Recoil/expenseRecord";
 
 export default function SubmitForm() {
   const [, setStartDate] = useRecoilState(startDateState);
   const [, setEndDate] = useRecoilState(endDateState);
   const [, setList] = useRecoilState(checkedListState);
   const [, setisFiltered] = useRecoilState(isfilteredState);
+  const [s, setSelectedDateForGetData] = useRecoilState(
+    selectedExpenseDateState
+  );
 
   const handleFilterReset = () => {
     setStartDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
     setEndDate(new Date());
     setList([]);
     setisFiltered(false);
+    setSelectedDateForGetData(new Date());
   };
   const setFilter = () => {
     setisFiltered(true);

--- a/src/components/Expenses/ExpensesForm.tsx
+++ b/src/components/Expenses/ExpensesForm.tsx
@@ -11,7 +11,6 @@ import * as Yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useMutation, useQueryClient } from "react-query";
 import InformModal from "../Common/InformModal";
-import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import tw from "twin.macro";
 import { BiWon } from "react-icons/Bi";
@@ -23,7 +22,11 @@ import { SHOW_MODAL_DELAY } from "../../constants/modalTime";
 import { postExpense, reviseExpense } from "../../api/expenseAPI";
 import { ExpenseFormProps } from "../../interface/interface";
 import { useRecoilState } from "recoil";
-import { expenseRecordAtom } from "../../Recoil/expenseRecord";
+import {
+  expenseRecordAtom,
+  selectedExpenseDateState,
+} from "../../Recoil/expenseRecord";
+import { startDateState, endDateState } from "../../Recoil";
 
 const Container = styled.div`
   ${tw`mx-auto w-11/12 pt-8 text-neutral-600 font-bold text-sm`}
@@ -44,7 +47,12 @@ const ExpensesForm = ({ formEditor }: ExpensesFormProps) => {
   );
   const [selectModal, setSelectModal] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [, setSelectedDateForGetData] = useRecoilState(
+    selectedExpenseDateState
+  );
   const [isRevision, setIsRevision] = useRecoilState(expenseRecordAtom);
+  const [, setStartDate] = useRecoilState(startDateState);
+  const [, setEndDate] = useRecoilState(endDateState);
   const expenseSchema = Yup.object({
     amount: Yup.string()
       .transform((value) => value.replace(/,/g, ""))
@@ -145,6 +153,15 @@ const ExpensesForm = ({ formEditor }: ExpensesFormProps) => {
     } else {
       updateAccountMutation.mutate(formdata);
     }
+    setSelectedDateForGetData(selectedDate);
+    setTimeout(() => {
+      setStartDate(
+        new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1)
+      );
+      setEndDate(
+        new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 0)
+      );
+    }, 100);
 
     if (!dialogRef.current) return;
     dialogRef.current.showModal();


### PR DESCRIPTION
### 1. 현재 달(7월)과 동일한 달의 지출을 수정하면 문제가 없지만, 현재 달과 다른 달의 지출을 수정하면 정상적으로 수정된 내용을 받아오지 않음.
- Reason: 데이터를 받아오는 부분에서 이미 Date로 filter가 걸려 있으나, 동일하게 Date로 필터가 되도록 함수가 작성되어 있었음.
- Reason: 수정 후 Data를 불러오는 과정에서 startDate와 endDate가 Default 값으로 데이터를 가져오도록 설정되어 있음.
- 해결: 필터 삭제 후 setTimeout으로 데이터를 이중으로 불러오도록 변경.(해결책이 맞는지는…)

### 2. 6월 가계부가 표시되는 상태에서 7월 지출등록을 할 경우, 가계부가 갱신되어 지출 내역은 7월이 표시되지만, 연월은 6월로 표시되는 문제
- Reason: 가계부에 표시되는 “연 월”이 지출 등록 시에 반영이되지 않게 설계가 되어 있음. (”연 월”이 바뀌면 가계부 표시에 반영이 되지만, 지출 등록 시 useMutation으로 받아오는 가계부 값과는 연동이 되어 있지 않음.
- 해결: Recoil을 사용하여 selectedDateForGetData값을 다른 Component에서도 사용할 수 있게 변경하고, 다른 Component에서도 selectedDateForGetData를 설정할 수 있게 변경. 6월 가계부에서 지출 등록(7월 데이터)을 할 경우, 지출 등록 후 7월 화면으로 넘어가도록 변경. 7월 가계부에서 지출등록(6월 데이터)을 할 경우, 지출 등록 후 6월 화면으로 넘어가도록 변경.

### 3.  필터 초기화 시 표시되는 가계부와 연월이 일치하지 않는 문제
- 해결: 초기화 시 selectedDateForGetData 값도 함께 초기화 할 수 있도록 추가.
