### PR TITLE
Challenge Home API 작성 및 필터 수정

### DIFF
--- a/src/Recoil/challengeHomeFilterAtom.ts
+++ b/src/Recoil/challengeHomeFilterAtom.ts
@@ -7,7 +7,7 @@ import {
 
 export const textCategoryState = atom({
   key: "text_category",
-  default: "total",
+  default: "ALL",
 });
 
 export const searchTextState = atom({ key: "searchText", default: "" });
@@ -20,7 +20,7 @@ export const maxSearchAmountState = atom({
   key: "max_amount",
   default: FIXED_MAX_VALUE,
 });
-export const searchCategoryState = atom({ key: "category", default: "all" });
+export const searchCategoryState = atom({ key: "category", default: "" });
 
 export const filterParameterSelector = selector({
   key: "filter_parameter",
@@ -29,14 +29,24 @@ export const filterParameterSelector = selector({
     const searchText = get(searchTextState);
     const minSearchAmount = get(minSearchAmountState);
     const maxSearchAmount = get(maxSearchAmountState);
-    const searchCategory = get(textCategoryState);
+    const searchCategory = get(searchCategoryState);
+
+    if (searchCategory === "") {
+      return {
+        searchType: textCategory,
+        keyword: searchText,
+        minAmount: minSearchAmount,
+        maxAmount: maxSearchAmount,
+        category: null,
+      };
+    }
 
     return {
-      text_category: textCategory,
-      search_text: searchText,
-      min_search_amount: minSearchAmount,
-      max_search_amount: maxSearchAmount,
-      search_category: searchCategory,
+      searchType: textCategory,
+      keyword: searchText,
+      minAmount: minSearchAmount,
+      maxAmount: maxSearchAmount,
+      category: searchCategory,
     };
   },
 });

--- a/src/api/challengeAPI.ts
+++ b/src/api/challengeAPI.ts
@@ -1,6 +1,6 @@
 import axios from "./axiosInterceptors";
 import { API } from "../constants/api";
-
+import { ChallengeFilterProps } from "../interface/interface";
 import { FieldValues } from "react-hook-form";
 
 //지우기
@@ -22,30 +22,23 @@ export const postChallenge = async (data: FieldValues, memberCount: number) => {
   }
 };
 
-export const getSearchChallenge = async (
-  keyword: string,
-  searchType: string,
-  minAmount: number,
-  maxAmount: number,
-  category: string,
-  page: number
+export const getChallengeList = async (
+  filterParameter: ChallengeFilterProps
 ) => {
   try {
     const response = await axios.get(`${API}/challenges/search`, {
       params: {
-        keyword: keyword,
-        searchType: searchType,
-        minAmount: minAmount,
-        maxAmount: maxAmount,
-        category: category,
-        page: page,
+        keyword: filterParameter.keyword,
+        searchType: filterParameter.searchType,
+        minAmount: filterParameter.minAmount,
+        maxAmount: filterParameter.maxAmount,
+        category: filterParameter.category,
+        page: 0,
       },
     });
     return response.data;
   } catch (error) {
-    console.error(
-      `getSearchChallenge Error : Time(${new Date()}) ERROR ${error}`
-    );
+    console.error(`getChallengeList : Time(${new Date()}) ERROR ${error}`);
   }
 };
 

--- a/src/components/AccountPage/Submit.tsx
+++ b/src/components/AccountPage/Submit.tsx
@@ -15,7 +15,7 @@ export default function SubmitForm() {
   const [, setEndDate] = useRecoilState(endDateState);
   const [, setList] = useRecoilState(checkedListState);
   const [, setisFiltered] = useRecoilState(isfilteredState);
-  const [s, setSelectedDateForGetData] = useRecoilState(
+  const [, setSelectedDateForGetData] = useRecoilState(
     selectedExpenseDateState
   );
 

--- a/src/components/Challenge/ChallengeCard.tsx
+++ b/src/components/Challenge/ChallengeCard.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router";
 import { dDayCalculator } from "../../helpers/helper";
 import { ChallengeDataProps } from "../../interface/interface";
 
@@ -6,18 +7,27 @@ export default function ChallengeCard({
 }: {
   challengeData: ChallengeDataProps;
 }) {
+  const navigate = useNavigate();
   const stardDDay = dDayCalculator(challengeData.startDate);
+  const handleClickCard = () => {
+    navigate(`/challenge/${challengeData.challengeId}`);
+  };
   return (
-    <div className="rounded-2xl border p-4 hover:bg-zinc-200 grid grid-cols-2 grid-rows-2 gap-y-1  items-center">
+    <div
+      onClick={handleClickCard}
+      className="rounded-2xl border p-4 hover:bg-zinc-200 grid grid-cols-2 grid-rows-2 gap-y-1  items-center"
+    >
       <div className="col-span-2">
         <p className="text-xl text-ellipsis overflow-hidden line-clamp-1 ">
           {challengeData.title}
         </p>
-        <p className="text-ellipsis overflow-hidden">{challengeData.content}</p>
+        <p className="text-ellipsis overflow-hidden">
+          {challengeData.challengeContent}
+        </p>
       </div>
       <div className=" col-span-1 h-full flex items-end">
         <p className="text-lg ">
-          {challengeData.goal_amount.toLocaleString("ko-KR")} 원
+          {challengeData.goalAmount.toLocaleString("ko-KR")} 원
         </p>
       </div>
       <div className=" col-span-1 text-right">

--- a/src/components/Challenge/ChallengeCategoryFilter.tsx
+++ b/src/components/Challenge/ChallengeCategoryFilter.tsx
@@ -1,13 +1,19 @@
+import { useState } from "react";
 import {
   Category,
   ChanllegeCategoryList,
 } from "../../constants/expenseCategory";
 
 export default function ChallengeCategoryFilter({
-  handleSelectCategory,
+  selected,
+  handleGetCategory,
 }: {
-  handleSelectCategory: (item: Category) => void;
+  selected: string;
+  handleGetCategory: (item: Category) => void;
 }) {
+  const handleGetCategoryFromList = (item: Category) => {
+    handleGetCategory(item);
+  };
   return (
     <>
       <div className="w-full grid grid-cols-5">
@@ -15,8 +21,10 @@ export default function ChallengeCategoryFilter({
           <button
             key={item.category}
             type="button"
-            onClick={() => handleSelectCategory(item)}
-            className="btn btn-ghost focus:border focus:bg-zinc-300 hover:bg-transparent w-full p-0 block col-span-1 h-20"
+            onClick={() => handleGetCategoryFromList(item)}
+            className={`btn btn-ghost w-full p-0 block col-span-1 h-20 ${
+              selected === item.category ? "bg-zinc-300" : "bg-white"
+            }`}
           >
             <div
               className={`${item.color} w-4/5 mx-auto text-base-100 mb-1 flex justify-center items-center h-10 rounded-full`}

--- a/src/components/Challenge/ChallengeFilter.tsx
+++ b/src/components/Challenge/ChallengeFilter.tsx
@@ -1,36 +1,34 @@
-import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState } from "recoil";
 
 import { FilterDropDown } from "../Common/Dropdown";
 import Slider from "../Common/Slider";
 import ChallengeCategoryFilter from "./ChallengeCategoryFilter";
 import {
-  textCategoryState,
   searchTextState,
-  minSearchAmountState,
-  maxSearchAmountState,
   searchCategoryState,
 } from "../../Recoil/challengeHomeFilterAtom";
 import { Category } from "../../constants/expenseCategory";
 
 const ChallengeFilterList = [
-  { value: "total", name: "전체" },
-  { value: "title", name: "제목" },
-  { value: "content", name: "부제" },
+  { value: "ALL", name: "전체" },
+  { value: "TITLE", name: "제목" },
+  { value: "CONTENT", name: "부제" },
 ];
-interface applyClickProps {
-  onClick: () => void;
-}
-export default function ChallengeFilter({ onClick }: applyClickProps) {
+export default function ChallengeFilter({
+  handleGetChallengeList,
+}: {
+  handleGetChallengeList: () => void;
+}) {
   const [searchText, setSearchText] = useRecoilState(searchTextState);
   const [searchCategory, setSearchCategory] =
     useRecoilState(searchCategoryState);
   const handleGetTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchText(e.target.value);
-    console.log(searchText);
   };
   const handleGetCategory = (item: Category) => {
     setSearchCategory(item.category);
   };
+
   const handleResetCategory = useResetRecoilState(searchCategoryState);
 
   return (
@@ -66,7 +64,8 @@ export default function ChallengeFilter({ onClick }: applyClickProps) {
           <div className="modal">
             <div className="modal-box">
               <ChallengeCategoryFilter
-                handleSelectCategory={handleGetCategory}
+                selected={searchCategory}
+                handleGetCategory={handleGetCategory}
               />
               <div className="w-full flex justify-center items-center mt-2">
                 <label
@@ -80,7 +79,7 @@ export default function ChallengeFilter({ onClick }: applyClickProps) {
                   htmlFor="category_filter"
                   onClick={handleResetCategory}
                 >
-                  닫기
+                  초기화
                 </label>
               </div>
             </div>
@@ -91,9 +90,8 @@ export default function ChallengeFilter({ onClick }: applyClickProps) {
             ></label>
           </div>
           <button
-            type="button"
-            onClick={onClick}
             className="btn btn-accent col-span-3 z-10"
+            onClick={handleGetChallengeList}
           >
             적용
           </button>

--- a/src/components/Challenge/ChallengeForm.tsx
+++ b/src/components/Challenge/ChallengeForm.tsx
@@ -25,6 +25,7 @@ export default function ChallengeForm() {
   const [endDate, setEndDate] = useState<Date>(addOneMonth(new Date()));
   const [openForm, setOpenForm] = useRecoilState(openFormState);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string>("");
   const navigate = useNavigate();
 
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -37,7 +38,7 @@ export default function ChallengeForm() {
   const challengeSchema = Yup.object({
     title: Yup.string().required("필수 입력 항목입니다."),
     goal_amount: Yup.number()
-      .max(10000000, "10000000원 이하로 입력해주세요")
+      .max(10000000, "10,000,000원 이하로 입력해주세요")
       .required("필수 입력 항목입니다."),
     category: Yup.string().required(
       "필수 입력 항목입니다. 카테고리를 선택해주세요."
@@ -151,8 +152,10 @@ export default function ChallengeForm() {
     setStartDate(new Date());
     setEndDate(addOneMonth(new Date()));
     setMemberCount(2);
+    setSelectedCategory("");
   };
   const handleSelectCategory = (item: Category) => {
+    setSelectedCategory(item.category);
     setValue("category", item.category);
   };
 
@@ -304,7 +307,8 @@ export default function ChallengeForm() {
                   </span>
                 )}
                 <ChallengeCategoryFilter
-                  handleSelectCategory={handleSelectCategory}
+                  selected={selectedCategory}
+                  handleGetCategory={handleSelectCategory}
                 />
                 {errors.category && (
                   <span className="message text-xs text-error text-center">

--- a/src/components/Challenge/ChallengeHome.tsx
+++ b/src/components/Challenge/ChallengeHome.tsx
@@ -9,7 +9,7 @@ import ChallengeFilter from "./ChallengeFilter";
 import ChallengeCard from "./ChallengeCard";
 import { ChallengeDataProps } from "../../interface/interface";
 import { openFormState } from "../../Recoil/challengeFormAtom";
-import { getSearchChallenge } from "../../api/challengeAPI";
+import { getChallengeList } from "../../api/challengeAPI";
 import { filterParameterSelector } from "../../Recoil/challengeHomeFilterAtom";
 
 const Container = styled.div`
@@ -19,38 +19,30 @@ const Container = styled.div`
 export default function ChallengeHome() {
   const [challengeData, setChallengeData] = useState<ChallengeDataProps[]>([]);
   const [, setOpenForm] = useRecoilState(openFormState);
-  const params = useRecoilValue(filterParameterSelector);
+  const filterValues = useRecoilValue(filterParameterSelector);
 
-  const getChallengeData = useCallback(async () => {
+  const handleGetFilteredChallengeData = async () => {
     try {
-      const response = await axios.get("/test/challengeHomeTest.json");
-      const result = response.data;
-      setChallengeData(result.challengeList);
+      const response = await getChallengeList(filterValues);
+      console.log(response.data.content);
+      setChallengeData(response.data.content);
     } catch (error) {
       console.error(
-        `getChallengeData Error: Time(${new Date()}) ERROR ${error}`
+        `handleGetFilteredChallengeData Error: Time(${new Date()}) ERROR ${error}`
       );
     }
-  }, []);
+  };
 
   useEffect(() => {
-    getChallengeData();
-  }, [getChallengeData]);
-  const page = 0;
-  const onApplyFilter = async () => {
-    await getSearchChallenge(
-      params.search_text,
-      params.text_category,
-      params.min_search_amount,
-      params.max_search_amount,
-      params.search_category,
-      page
-    );
-  };
+    handleGetFilteredChallengeData();
+  }, []);
+
   return (
     <>
       <Container>
-        <ChallengeFilter onClick={onApplyFilter} />
+        <ChallengeFilter
+          handleGetChallengeList={handleGetFilteredChallengeData}
+        />
         <ChallengeCardWarp>
           {challengeData.map((item) => (
             <div key={item.challengeId} className="mb-4">

--- a/src/constants/challengeSliderFilter.ts
+++ b/src/constants/challengeSliderFilter.ts
@@ -1,3 +1,3 @@
 export const FIXED_MIN_VALUE = 0;
-export const FIXED_MAX_VALUE = 2000000;
-export const RANGE_STEP = 100000;
+export const FIXED_MAX_VALUE = 10000000;
+export const RANGE_STEP = 1000000;

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -70,8 +70,8 @@ export interface SliderBarProps {
 export interface ChallengeDataProps {
   readonly challengeId: number;
   readonly title: string;
-  readonly content: string;
-  readonly goal_amount: number;
+  readonly challengeContent: string;
+  readonly goalAmount: number;
   readonly startDate: string;
   readonly endDate: string;
   readonly maxPeople: number;


### PR DESCRIPTION
### 1. Challenge Home API 작성(조회) 및 수정
### 2. Challenge Home 필터 수정
- 챌린지 등록/챌린지 필터 양 쪽의 카테고리를 별개의 변수로 받아오도록 변경
- 선택된 필터가 표시되도록 수정(focus에서 조건문으로 수정)
### 3. 일부 UI 수정
- Slider 수정
- 경고 문구에 콤마 입력(10000000 -> 10,000,000원)
- 불필요한 코드 삭제