### PR TITLE
마무리 리팩토링

### DIFF
--- a/src/api/axiosInterceptors.ts
+++ b/src/api/axiosInterceptors.ts
@@ -34,6 +34,13 @@ axios.interceptors.response.use(
         originalRequest.headers.Refreshtoken = refreshToken;
         return axios(originalRequest);
       }
+      if (
+        response.data.errorCode === "MISMATCH_REFRESH_TOKEN" ||
+        response.data.errorCode === "NOT_EXIST_REFRESH_TOKEN"
+      ) {
+        localStorage.clear();
+        return;
+      }
     }
     return Promise.reject(error);
   }

--- a/src/components/AccountPage/Account.tsx
+++ b/src/components/AccountPage/Account.tsx
@@ -148,8 +148,8 @@ export default function Account() {
 
   return (
     <main>
-      <div className=" w-11/12 ml-auto mr-auto flex flex-col items-center  pb-20">
-        <div className=" w-full ml-auto mr-auto flex flex-col items-center mt-4 mb-4">
+      <div className=" w-full px-2 ml-auto mr-auto flex flex-col items-center pt-4 pb-20">
+        <div className=" w-full ml-auto mr-auto flex flex-col items-center mb-4">
           <div className="w-full flex flex-col items-center ">
             <div className="w-full flex justify-start items-center my-4 mt-5">
               <MonthPickerWrapper className="w-full flex items-center justify-start text-cyan-950">

--- a/src/components/Challenge/ChallengeHome.tsx
+++ b/src/components/Challenge/ChallengeHome.tsx
@@ -18,7 +18,7 @@ import { IoCreateOutline } from "react-icons/Io5";
 import { TiPlus } from "react-icons/ti";
 
 const Container = styled.div`
-  ${tw`mx-auto relative w-11/12  pt-8 text-neutral-600 font-bold text-sm overflow-hidden`}
+  ${tw`mx-auto relative w-full px-2  pt-4 text-neutral-600 font-bold text-sm overflow-hidden`}
 `;
 
 export default function ChallengeHome() {

--- a/src/components/Challenge/ChallengeResult.tsx
+++ b/src/components/Challenge/ChallengeResult.tsx
@@ -49,7 +49,7 @@ const ChallengeResult = ({ data }: ChallengeDataProps) => {
 
   return (
     <ArticleContainer>
-      <div className="w-11/12 mx-auto">
+      <div className="w-full px-2 mx-auto">
         <div className="flex items-center justify-center bg-teal-50  rounded-lg h-12 shadow mb-3 ">
           <div className="mx-2 mt-1 text-cyan-950 text-base leading-6">
             도전 종료!!

--- a/src/components/Challenge/ChallengeStatus.tsx
+++ b/src/components/Challenge/ChallengeStatus.tsx
@@ -39,7 +39,7 @@ const ChallengeStatus = ({ data, category }: ChallengeDataProps) => {
 
   return (
     <ArticleContainer>
-      <div className="w-11/12 mx-auto">
+      <div className="w-full px-2 mx-auto">
         <div className="text-cyan-950 text-sm flex justify-center items-center bg-teal-50  rounded-lg  shadow py-3 mb-2">
           <GiTwoCoins size={17} className="text-yellow-400 mr-1" />
           <div className="mr-2">목표금액</div>

--- a/src/components/Challenge/MembersStatus.tsx
+++ b/src/components/Challenge/MembersStatus.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import {
   ChallengeMemberData,
   ChallengeMemberResultData,
+  UserData,
   UserInfo,
 } from "../../interface/interface";
 import axios from "axios";
@@ -11,6 +12,8 @@ import tw from "twin.macro";
 import { BiWon } from "react-icons/Bi";
 import { FaHeartBroken } from "react-icons/Fa";
 import { AiTwotoneCrown } from "react-icons/Ai";
+import { useUser } from "../../api/membersAPI";
+import { UseQueryResult } from "react-query";
 
 interface Props {
   readonly data: ChallengeMemberData | ChallengeMemberResultData;
@@ -56,12 +59,12 @@ const MembersStatus = ({ data, top }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean | null>(null);
   const [isFirst, setIsFirst] = useState<boolean | null>(null);
   const [myStatus, setMyStatus] = useState<boolean>(false);
+  const { data: userInfo }: UseQueryResult<UserData> = useUser();
   const ttlAmount = data.totalAmount.toLocaleString("ko-KR");
 
-  const memberId = data.memberId;
-
   useEffect(() => {
-    if (data.memberId === memberId) {
+    console.log(data);
+    if (data.memberId === userInfo?.memberId) {
       setMyStatus(true);
     } else {
       setMyStatus(false);

--- a/src/components/Member/Signup.tsx
+++ b/src/components/Member/Signup.tsx
@@ -111,7 +111,7 @@ export default function SignUp() {
 
   return (
     <>
-      <div className=" w-11/12 ml-auto mr-auto flex flex-col justify-center items-center mt-5">
+      <div className="mx-auto h-screen w-11/12 text-neutral-500 text-sm flex flex-col justify-center items-center py-15 overflow-y-auto">
         <form
           onSubmit={handleSubmit(onSubmit)}
           className="w-full text-cyan-950 flex flex-col justify-center items-center mt-10 mb-4"

--- a/src/components/MyPage/NicknameForm.tsx
+++ b/src/components/MyPage/NicknameForm.tsx
@@ -114,7 +114,7 @@ const NicknameForm = ({ formEditor, informChangeRef }: Props) => {
             maxLength={11}
             spellCheck={false}
             autoFocus
-            className="outline-none pl-2 h-10 mt-5 placeholder:text-xs placeholder:font-light"
+            className="outline-none rounded-lg w-full indent-2 h-10 mt-5 placeholder:text-xs placeholder:font-light"
             {...register("nickname")}
           />
           {duplicationCheck.check ? (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -95,7 +95,7 @@ export default function Home() {
 
   return (
     <Container>
-      <div className="w-11/12 mx-auto">
+      <div className="w-full px-2 mx-auto">
         <ProfileContainer>
           <ProfileImgContainer>
             {userInfo?.profileImageUrl ? (
@@ -189,7 +189,7 @@ export default function Home() {
 }
 
 const Container = styled.main`
-  ${tw` bg-base-color pt-7 text-neutral-500 font-bold text-sm`}
+  ${tw` bg-base-color pt-4 text-neutral-500 font-bold text-sm`}
 `;
 
 const ProfileContainer = styled.div`

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -19,7 +19,7 @@ import { kakaoLogout } from "../api/kakaoAPI";
 import { KAKAO_LOGOUT_URL } from "../constants/api";
 
 const Container = styled.div`
-  ${tw`mx-auto w-11/12 pt-8 text-neutral-600 font-bold text-sm`}
+  ${tw`mx-auto w-full pt-4 px-2 text-neutral-600 font-bold text-sm`}
 `;
 
 const MyPage = () => {
@@ -87,7 +87,7 @@ const MyPage = () => {
     <>
       <main>
         <Container>
-          <div className="p-1 pt-3 bg-base-100 rounded-t-lg">
+          <div className="p-1 pt-3 rounded-t-lg">
             <div className="flex items-center justify-between w-full  pb-4  border-b border-accent-focus/60">
               <div className="relative">
                 <div className="w-20 h-20  rounded-full overflow-hidden bg-[#f0f8f6] text-accent shadow-lg">
@@ -119,7 +119,7 @@ const MyPage = () => {
                       onClick={() => {
                         setNicknameForm(true);
                       }}
-                      className="btn btn-sm btn-ghost bg-base-color hover:bg-base-color shadow mr-2"
+                      className="btn btn-sm btn-ghost bg-base-100 hover:bg-base-color shadow mr-2"
                     >
                       수정
                     </button>
@@ -135,7 +135,7 @@ const MyPage = () => {
             />
           ) : (
             <div>
-              <div className="bg-base-100 rounded-b-lg px-1 pb-2 mb-2">
+              <div className=" rounded-b-lg px-1 pb-2 mb-2">
                 <div className="flex items-center w-full h-16 p-2 border-b border-accent-focus/60">
                   <div className="w-1/4">이메일</div>
                   <div className="font-normal ">{userInfo?.email}</div>

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -5,7 +5,7 @@ const GlobalStyles = createGlobalStyle`
 
 main{
   min-height: calc(100vh - 65px);
-  ${tw`bg-base-color`}
+  ${tw`bg-base-color/70`}
 }
 
 /* iOS only */


### PR DESCRIPTION
**1. 로그인관련 리팩토링**
로그인했던 계정을 로그아웃 하지 않고 다른 기기로 로그인하면 기존 리프레쉬 토큰이 만료되는데, 이 상태에서 다시 처음로그인했던 기기에서 사이트에 진입하면 로컬스토리지에 isLogin이 있기 때문에 바로 홈으로 넘어가지만 리프레시 토큰이 만료됨에 따라 에러가 나는 걸 발견했습니다.
응답인터셉터 수정하여 관련된 에러코드를 받을 경우 로컬스토리지를 지워서 로그인 페이지로 리다이렉트되게 했습니다.

**2. 챌린지 멤버별 현황 리팩토링**
로그인한 유저아이디와 각 내역의 멤버아이디 비교해서 동일할 경우 나의 내역이라는 표시로 바탕색을 달리하는데, 모두 나의 내역으로 떠서 보니 로그인한 유저의 아이디가 아닌 각 내역의 아이디끼리 잘못 비교되고 있어 수정했습니다.

**3. 화면 컨테이너 사이즈 수정**
핸드폰에서 봤을때 컨텐츠 너비가 좀 답답해서 더 채우도록 수정했습니다.